### PR TITLE
Change naming of decorators

### DIFF
--- a/packages/prismy/readme.md
+++ b/packages/prismy/readme.md
@@ -30,10 +30,10 @@ npm i micro prismy tslib
 1. Create `index.ts`
 
 ```ts
-import { prismy, injectJsonBody } from 'prismy'
+import { prismy, JsonBody } from 'prismy'
 
 export class MyHandler {
-  async execute(@injectJsonBody() body: any) {
+  async execute(@JsonBody() body: any) {
     await doSomethingWithBody(body)
     return {
       message: 'Done!'

--- a/packages/prismy/src/selectors/bufferBody.ts
+++ b/packages/prismy/src/selectors/bufferBody.ts
@@ -14,6 +14,6 @@ export function selectBufferBody(
   }
 }
 
-export function injectBufferBody(options?: SelectBufferBodyOptions) {
+export function BufferBody(options?: SelectBufferBodyOptions) {
   return createInjectDecorators(selectBufferBody(options))
 }

--- a/packages/prismy/src/selectors/header.ts
+++ b/packages/prismy/src/selectors/header.ts
@@ -8,6 +8,6 @@ export function selectHeader(
   }
 }
 
-export function injectHeader(key: string) {
+export function Header(key: string) {
   return createInjectDecorators(selectHeader(key))
 }

--- a/packages/prismy/src/selectors/jsonBody.ts
+++ b/packages/prismy/src/selectors/jsonBody.ts
@@ -14,6 +14,6 @@ export function selectJsonBody(
   }
 }
 
-export function injectJsonBody(options?: SelectJsonBodyOptions) {
+export function JsonBody(options?: SelectJsonBodyOptions) {
   return createInjectDecorators(selectJsonBody(options))
 }

--- a/packages/prismy/src/selectors/method.ts
+++ b/packages/prismy/src/selectors/method.ts
@@ -6,6 +6,6 @@ export function selectMethod(): Selector<string | undefined> {
   }
 }
 
-export function injectMethod() {
+export function Method() {
   return createInjectDecorators(selectMethod())
 }

--- a/packages/prismy/src/selectors/query.ts
+++ b/packages/prismy/src/selectors/query.ts
@@ -19,10 +19,6 @@ export function selectQuery(
   }
 }
 
-export function injectQuery(
-  sep?: string,
-  eq?: string,
-  options?: SelectQueryOptions
-) {
+export function Query(sep?: string, eq?: string, options?: SelectQueryOptions) {
   return createInjectDecorators(selectQuery(sep, eq, options))
 }

--- a/packages/prismy/src/selectors/textBody.ts
+++ b/packages/prismy/src/selectors/textBody.ts
@@ -14,6 +14,6 @@ export function selectTextBody(
   }
 }
 
-export function injectTextBody(options?: SelectTextBodyOptions) {
+export function TextBody(options?: SelectTextBodyOptions) {
   return createInjectDecorators(selectTextBody(options))
 }

--- a/packages/prismy/src/selectors/url.ts
+++ b/packages/prismy/src/selectors/url.ts
@@ -20,10 +20,7 @@ export function selectUrl(
   }
 }
 
-export function injectUrl(
-  parseQueryString?: boolean,
-  slashesDenoteHost?: boolean
-) {
+export function Url(parseQueryString?: boolean, slashesDenoteHost?: boolean) {
   return createInjectDecorators(
     selectUrl(parseQueryString as any, slashesDenoteHost)
   )

--- a/packages/prismy/src/specs/createInjectDecorators.spec.ts
+++ b/packages/prismy/src/specs/createInjectDecorators.spec.ts
@@ -8,9 +8,9 @@ import {
 describe('createInjectDecorators', () => {
   it('sets a selector.', () => {
     const selectUrl: Selector<string | undefined> = req => req.url
-    const injectUrl = createInjectDecorators(selectUrl)
+    const StringUrl = createInjectDecorators(selectUrl)
     class MyHandler {
-      execute(@injectUrl url: string) {
+      execute(@StringUrl url: string) {
         return {
           url
         }
@@ -23,9 +23,9 @@ describe('createInjectDecorators', () => {
 
   it('throws when inject decorator is applied to other methods.', () => {
     expect(() => {
-      const injectUrl = createInjectDecorators(req => req.url)
+      const StringUrl = createInjectDecorators(req => req.url)
       class MyHandler {
-        test(@injectUrl url: string) {
+        test(@StringUrl url: string) {
           return {
             url
           }

--- a/packages/prismy/src/specs/prismy.spec.ts
+++ b/packages/prismy/src/specs/prismy.spec.ts
@@ -2,7 +2,7 @@ import http from 'http'
 import micro from 'micro'
 import listen from 'test-listen'
 import got from 'got'
-import { prismy, createInjectDecorators, injectTextBody, SendResult } from '..'
+import { prismy, createInjectDecorators, TextBody, SendResult } from '..'
 import { testServer } from './testServer'
 
 console.error = jest.fn()
@@ -31,9 +31,9 @@ describe('prismy', () => {
   })
 
   it('injects via a selector', async () => {
-    const injectUrl = createInjectDecorators(req => req.url)
+    const StringUrl = createInjectDecorators(req => req.url)
     class MyHandler {
-      execute(@injectUrl url: string) {
+      execute(@StringUrl url: string) {
         return url
       }
     }
@@ -48,9 +48,9 @@ describe('prismy', () => {
   })
 
   it('injects via multiple selectors', async () => {
-    const injectUrl = createInjectDecorators(req => req.url)
+    const StringUrl = createInjectDecorators(req => req.url)
     class MyHandler {
-      execute(@injectUrl url: string, @injectTextBody() textBody: string) {
+      execute(@StringUrl url: string, @TextBody() textBody: string) {
         return {
           url,
           textBody
@@ -73,9 +73,9 @@ describe('prismy', () => {
   })
 
   it('sets statusCode via SendResult', async () => {
-    const injectUrl = createInjectDecorators(req => req.url)
+    const StringUrl = createInjectDecorators(req => req.url)
     class MyHandler {
-      execute(@injectUrl url: string) {
+      execute(@StringUrl url: string) {
         return new SendResult(201, url)
       }
     }

--- a/packages/prismy/src/specs/selectors/bufferBody.spec.ts
+++ b/packages/prismy/src/specs/selectors/bufferBody.spec.ts
@@ -1,12 +1,12 @@
 import got from 'got'
 import { testServer } from '../testServer'
-import { injectBufferBody } from '../../'
+import { BufferBody } from '../../'
 
-describe('injectBufferBody', () => {
+describe('BufferBody', () => {
   it('injects parsed buffer body', async () => {
     let parsedBody: Buffer
     class MyHandler {
-      execute(@injectBufferBody() body: Buffer) {
+      execute(@BufferBody() body: Buffer) {
         parsedBody = body
         return body
       }

--- a/packages/prismy/src/specs/selectors/header.spec.ts
+++ b/packages/prismy/src/specs/selectors/header.spec.ts
@@ -1,11 +1,11 @@
-import { injectHeader } from '../../selectors'
+import { Header } from '../../selectors'
 import { testServer } from '../testServer'
 import got from 'got'
 
-describe('injectHeader', () => {
+describe('Header', () => {
   it('injects a header value', async () => {
     class MyHandler {
-      execute(@injectHeader('x-test') xTest: string) {
+      execute(@Header('x-test') xTest: string) {
         return xTest
       }
     }

--- a/packages/prismy/src/specs/selectors/jsonBody.spec.ts
+++ b/packages/prismy/src/specs/selectors/jsonBody.spec.ts
@@ -1,11 +1,11 @@
-import { injectJsonBody } from '../../selectors'
+import { JsonBody } from '../../selectors'
 import { testServer } from '../testServer'
 import got from 'got'
 
-describe('injectJsonBody', () => {
+describe('JsonBody', () => {
   it('injects parsed json body', async () => {
     class MyHandler {
-      execute(@injectJsonBody() body: any) {
+      execute(@JsonBody() body: any) {
         return body
       }
     }

--- a/packages/prismy/src/specs/selectors/method.spec.ts
+++ b/packages/prismy/src/specs/selectors/method.spec.ts
@@ -1,11 +1,11 @@
-import { injectMethod } from '../../selectors'
+import { Method } from '../../selectors'
 import { testServer } from '../testServer'
 import got from 'got'
 
-describe('injectMethod', () => {
+describe('Method', () => {
   it('injects method', async () => {
     class MyHandler {
-      execute(@injectMethod() method: string) {
+      execute(@Method() method: string) {
         return method
       }
     }

--- a/packages/prismy/src/specs/selectors/query.spec.ts
+++ b/packages/prismy/src/specs/selectors/query.spec.ts
@@ -1,11 +1,11 @@
-import { injectQuery } from '../../selectors'
+import { Query } from '../../selectors'
 import { testServer } from '../testServer'
 import got from 'got'
 
-describe('injectQuery', () => {
+describe('Query', () => {
   it('injects query', async () => {
     class MyHandler {
-      execute(@injectQuery() query: any) {
+      execute(@Query() query: any) {
         return query
       }
     }

--- a/packages/prismy/src/specs/selectors/textBody.spec.ts
+++ b/packages/prismy/src/specs/selectors/textBody.spec.ts
@@ -1,12 +1,12 @@
 import got from 'got'
 import { testServer } from '../testServer'
-import { injectTextBody } from '../../'
+import { TextBody } from '../../'
 
-describe('injectTextBody', () => {
+describe('TextBody', () => {
   it('injects parsed text body', async () => {
     let parsedBody: string
     class MyHandler {
-      execute(@injectTextBody() body: string) {
+      execute(@TextBody() body: string) {
         parsedBody = body
         return body
       }

--- a/packages/prismy/src/specs/selectors/url.spec.ts
+++ b/packages/prismy/src/specs/selectors/url.spec.ts
@@ -1,12 +1,12 @@
 import got from 'got'
 import { UrlObject } from 'url'
 import { testServer } from '../testServer'
-import { injectUrl } from '../../'
+import { Url } from '../../'
 
-describe('injectUrl', () => {
+describe('Url', () => {
   it('injects url', async () => {
     class MyHandler {
-      execute(@injectUrl() url: UrlObject) {
+      execute(@Url() url: UrlObject) {
         return url
       }
     }


### PR DESCRIPTION
Use pascal case rather than camel case
`injectQuery` -> `Query`
