### PR TITLE
.nojekyll for docs and gh-page dir structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test-coverage": "jest --coverage",
     "codecov": "codecov -f coverage/*.json",
     "prepublishOnly": "npm test && npm run build",
-    "generate-docs": "typedoc --out out src && sh scripts/generate-docs.sh"
+    "generate-docs": "typedoc --out out/docs src && sh scripts/generate-docs.sh"
   },
   "bugs": {
     "url": "https://github.com/prismyland/prismy/issues"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test-coverage": "jest --coverage",
     "codecov": "codecov -f coverage/*.json",
     "prepublishOnly": "npm test && npm run build",
-    "generate-docs": "typedoc --out out/docs src && sh scripts/generate-docs.sh"
+    "generate-docs": "typedoc src && sh scripts/generate-docs.sh"
   },
   "bugs": {
     "url": "https://github.com/prismyland/prismy/issues"

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -7,6 +7,7 @@ fi
 
 cd $DIR
 git init
+touch .nojekyll
 git checkout -b gh-pages
 git add -A
 git commit -a -m "Deployed at $(date)"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,19 +27,6 @@
   },
   "typedocOptions": {
     "out": "out",
-    "target": "es2018",
     "mode": "file",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "exclude": "specs/**/*.ts",
-    "includes": "src/**/*.ts",
-    "ignoreCompilerErrors": true,
-    "excludePrivate": true,
-    "excludeNotExported": true,
-    "stripInternal": true,
-    "suppressExcessPropertyErrors": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "hideGenerator": true,
-    "readme": "readme.md"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,20 +26,20 @@
     "suppressImplicitAnyIndexErrors": true
   },
   "typedocOptions": {
-		"out": "out",
+    "out": "out",
     "target": "es2018",
     "mode": "file",
-		"module": "commonjs",
-		"moduleResolution": "node",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "exclude": "specs/**/*.ts",
     "includes": "src/**/*.ts",
-		"ignoreCompilerErrors": true,
-		"excludePrivate": true,
-		"excludeNotExported": true,
-		"stripInternal": true,
-		"suppressExcessPropertyErrors": true,
-		"suppressImplicitAnyIndexErrors": true,
-		"hideGenerator": true,
-		"readme": "readme.md"
-	}
+    "ignoreCompilerErrors": true,
+    "excludePrivate": true,
+    "excludeNotExported": true,
+    "stripInternal": true,
+    "suppressExcessPropertyErrors": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "hideGenerator": true,
+    "readme": "readme.md"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,22 @@
     "noFallthroughCasesInSwitch": true,
 
     "suppressImplicitAnyIndexErrors": true
-  }
+  },
+  "typedocOptions": {
+		"out": "out",
+    "target": "es2018",
+    "mode": "file",
+		"module": "commonjs",
+		"moduleResolution": "node",
+    "exclude": "specs/**/*.ts",
+    "includes": "src/**/*.ts",
+		"ignoreCompilerErrors": true,
+		"excludePrivate": true,
+		"excludeNotExported": true,
+		"stripInternal": true,
+		"suppressExcessPropertyErrors": true,
+		"suppressImplicitAnyIndexErrors": true,
+		"hideGenerator": true,
+		"readme": "readme.md"
+	}
 }


### PR DESCRIPTION
gh-pages and doc generation

- script creates .nojekyll file
- typedoc outputs to doc directory inside out to support gh-pages
- typedoc settings fixes.
  - mode setting must be `file` for desired layout.
  - only necessary config options