### PR TITLE
alias for standard and async ResponseObject

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,20 @@ export interface ResponseObject<B> {
 }
 
 /**
+ * shorter type alias for ResponseObject<B>
+ * 
+ * @public
+ */
+export type Res<B> = ResponseObject<B>
+
+/**
+ * alias for Promise<ResponseObject<B>> for user with async handlers
+ * 
+ * @public
+ */
+export type AsyncRes<B> = Promise<ResponseObject<B>>
+
+/**
  * prismy compaticble middleware
  * 
  * @public


### PR DESCRIPTION
- `type Res<B>` as an short alias of `ResponseObject<B>` to help declutter code.
- `type AsyncRes<B>` as a short alias of `Promise<ResponseObject<B>>` as many handlers are async.